### PR TITLE
Use alternative function to get version

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -44,7 +44,8 @@ add_shortcode(
  */
 function md_react_app_enqueue_assets() {
 
-	$ver         = ( get_plugin_data( __FILE__ ) )['Version'];
+
+	$ver         = (get_file_data( __FILE__, ["Version" => "Version"], false ))['Version'];
 	$js_to_load  = plugin_dir_url( __FILE__ ) . 'app/build/static/js/main.js';
 	$css_to_load = plugin_dir_url( __FILE__ ) . 'app/build/static/css/main.css';
 


### PR DESCRIPTION
I was getting PHP errors when loading the page with the short code from this plugin. After some light investigation, it seems that `get_file_data()` is not included by default on the frontend (https://wordpress.stackexchange.com/a/17950/82806). I based the update on this Stack Overflow answer: https://wordpress.stackexchange.com/a/285644/82806.